### PR TITLE
解決 issue 將 2018 的資料改為靜態 #135 

### DIFF
--- a/2018/src/Utils/ApiDataGetter.php
+++ b/2018/src/Utils/ApiDataGetter.php
@@ -1,0 +1,45 @@
+<?php
+namespace MopCon2018\Utils;
+
+class ApiDataGetter
+{
+    /*
+        在沒有 static file 的情況下可以 call 此 class 完成下載 static file 
+        usage: 
+            $getter = new ApiDataGetter(); 資料就從網路上抓回來
+    */
+    protected $baseDir;
+    protected $jsonList;
+    protected $api;
+    protected $apiData;
+    public function __construct()
+    {
+        $this->baseDir = '../../assets/json/';
+        $this->jsonList = ['Sponsor','Community','Volunteer','Carousel','News','Speaker'];
+        $this->api = new Api();
+        $this->apiData = [
+            $this->api->getSponsor(),
+            $this->api->getCommunity(),
+            $this->api->getVolunteer(),
+            $this->api->getCarousel(),
+            $this->api->getNews(),
+            $this->api->getSpeaker()
+        ];
+        foreach($jsonList as $key => $items)
+        {
+            $JoinPath = $baseDir.$items.'.json';
+            $tempJson = $apiData[$key];
+            $fp = fopen($JoinPath, 'w');
+            fwrite($fp, $tempJson);
+            fclose($fp);
+        }
+    }
+    /*
+        獲得往存放 json 資料夾的路徑 
+        usage: 
+            $path = $getter->getPath();
+    */
+    public function getPath(){
+        return $this->baseDir;
+    }
+}

--- a/2018/src/Utils/StaticApi.php
+++ b/2018/src/Utils/StaticApi.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace MopCon2018\Utils;
+
+class StaticApi extends Api
+/*
+    取代原本 Api 使用靜態檔案，介面與 Api 完全相同，內部實作不一樣而已。
+*/
+{
+    protected $baseDir;
+    public function __construct()
+    {
+        $this->baseDir = '../../assets/json/';
+    }
+    public function getSponsor()
+    {
+        $JoinPath = $this->baseDir.'Sponsor.json';
+        if(!file_exists($JoinPath)){
+            $getter = new ApiDataGetter();
+        }
+        $JsonString = file_get_contents($JoinPath);
+        return json_decode($JsonString, true);
+    }
+    public function getCommunity()
+    {
+        $JoinPath = $this->baseDir.'Community.json';
+        if(!file_exists($JoinPath)){
+            $getter = new ApiDataGetter();
+        }
+        $JsonString = file_get_contents($JoinPath);
+        return json_decode($JsonString, true);
+    }
+    public function getVolunteer()
+    {
+        $JoinPath = $this->baseDir.'Volunteer.json';
+        if(!file_exists($JoinPath)){
+            $getter = new ApiDataGetter();
+        }
+        $JsonString = file_get_contents($JoinPath);
+        return json_decode($JsonString, true);
+    }
+    public function getCarousel()
+    {
+        $JoinPath = $this->baseDir.'Carousel.json';
+        if(!file_exists($JoinPath)){
+            $getter = new ApiDataGetter();
+        }
+        $JsonString = file_get_contents($JoinPath);
+        return json_decode($JsonString, true);
+    }
+    public function getNews()
+    {
+        $JoinPath = $this->baseDir.'News.json';
+        if(!file_exists($JoinPath)){
+            $getter = new ApiDataGetter();
+        }
+        $JsonString = file_get_contents($JoinPath);
+        return json_decode($JsonString, true);
+    }
+    public function getSpeaker()
+    {
+        $JoinPath = $this->baseDir.'Speaker.json';
+        if(!file_exists($JoinPath)){
+            $getter = new ApiDataGetter();
+        }
+        $JsonString = file_get_contents($JoinPath);
+        return json_decode($JsonString, true);
+    }
+}


### PR DESCRIPTION
ApiDataGetter，使用原本的 API 並把它存成靜態檔案
StaticApi 繼承了 Api 並把相關的 function 改以靜態檔案讀取，若沒有檔案他會去 call ApiDataGetter 來獲得檔案

**問題**
我只讓 StaticApi 跟 Api 還有 ApiDataGetter 在同一個 namespace 底下，好像彼此看不到對方，是要用use嗎，但我上網查過了，但沒有很理解 namespace 跟 use 之間的關係