### PR TITLE
Add build 2019 website deploy script

### DIFF
--- a/adm/_github_hook.php
+++ b/adm/_github_hook.php
@@ -45,6 +45,10 @@ if (is_file($composer_lock_path)) {
 exec("cd {$doc_root} && npm install");
 exec("cd {$doc_root} && bower install");
 
+// Build 2019 web site
+exec("cd {$doc_root}2019-dev && yarn install");
+exec("yarn run generate");
+
 // 如果有 memcache，把最新的 deploy 狀況寫入 memcache
 $memcache_ok = function_exists("memcache_connect");
 if ($memcache_ok) {


### PR DESCRIPTION
增加 build 2019 官網的流程

# 前置作業

1. 安裝 nvm 並且設定 `/etc/profile.d/nvm.sh` 讓所有使用者都可以適用 default 版本的 node version
2. default node version 為 v8.11.0
3. 測試手動安裝 `cd 2019-dev && yarn install && yarn run generate` 可以正常使用