### PR TITLE
use specific node version

### DIFF
--- a/adm/_github_hook.php
+++ b/adm/_github_hook.php
@@ -42,12 +42,11 @@ if (is_file($composer_lock_path)) {
     echo "'{$composer_lock_path}' does not exist, do not composer update";
 }
 
-exec("cd {$doc_root} && npm install");
-exec("cd {$doc_root} && bower install");
+exec("cd {$doc_root} && /usr/local/nvm/versions/node/v8.11.0/bin/npm install");
 
 // Build 2019 web site
-exec("cd {$doc_root}2019-dev && yarn install");
-exec("yarn run generate");
+exec("cd {$doc_root}2019-dev && /usr/local/nvm/versions/node/v8.11.0/bin/yarn install");
+exec("cd {$doc_root}2019-dev && /usr/local/nvm/versions/node/v8.11.0/bin/yarn run generate");
 
 // 如果有 memcache，把最新的 deploy 狀況寫入 memcache
 $memcache_ok = function_exists("memcache_connect");


### PR DESCRIPTION
目前採用 root 安裝 nvm 來指定安裝 v8.11.0 版本的 node，並且有設定 default version 是 v8.11.0 且於 `/etc/profile.d/nvm.sh` 設定讓其他 user 應該也有可以抓到 default 的 node version

但看起來沒這麼順利，在安裝的時候還是會找不到 npm, node, yarn 等指令，我這邊打算直接寫死 node 相關執行檔的路徑，讓 www-data user 在 deploy 階段可以抓到正確的 node version

暫時就先這樣處理了（汗...