### PR TITLE
Add ApiTrait

### DIFF
--- a/api/app/Http/Controllers/ApiTrait.php
+++ b/api/app/Http/Controllers/ApiTrait.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Http\Controllers;
+
+trait ApiTrait
+{
+    /**
+     * Api Controller return success response
+     *
+     * @param string $message
+     * @param array  $data
+     * @param array  $field
+     * @return mixed
+     */
+    public function returnSuccess($message = '', $data = [], $field = [])
+    {
+        $field['data'] = $data;
+        return response()->json(array_merge([
+            'success' => true,
+            'message' => $message,
+        ], $field), 200);
+    }
+
+    /**
+     * return bad request status response
+     *
+     * @param string $message
+     * @param array $data
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function returnError($message = '', $data = [])
+    {
+        return response()->json([
+            'success' => false,
+            'message' => $message,
+            'data'    => $data
+        ], 400);
+    }
+
+    /**
+     * return not found response
+     *
+     * @param string $message
+     * @param array $data
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function returnNotFoundError($message = 'Not found', $data = [])
+    {
+        return response()->json([
+            'success' => false,
+            'message' => $message,
+            'data'    => $data
+        ], 404);
+    }
+
+    /**
+     * return 500 error response
+     *
+     * @param string $message
+     * @param array $data
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function returnServerError($message = 'Something Wrong', $data = [])
+    {
+        return response()->json([
+            'success' => false,
+            'message' => $message,
+            'data'    => $data
+        ], 500);
+    }
+
+    /**
+     * UnAuth return
+     *
+     * @param string $message
+     * @param array $data
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function returnUnAuthError($message = 'You have no permission', $data = [])
+    {
+        return response()->json([
+            'success' => false,
+            'message' => $message,
+            'data'    => $data
+        ], 401);
+    }
+}


### PR DESCRIPTION
訂定 api response 格式，讓輸出的格式都使用統一的格式， sample 如下

```
{
   'success': true / false,
   'message': 'something',
   'data': {
....
   {
}
```

目前定義的 api response function 為常用的 200, 400, 401, 404, 500 5 種，使用方式

```
  1 <?php
  2
  3 namespace App\Http\Controllers;
  4
  5 class FacebookController extends Controller
  6 {
  7     use ApiTrait;
```