### PR TITLE
Add new data in facebook api posts

### DIFF
--- a/api/docs/facebook.md
+++ b/api/docs/facebook.md
@@ -42,7 +42,10 @@ Returns json data about a facebook information.
             'full_picture' : {imageUrl},
             'message' : {貼文內容},
             'id': {貼文ID}, // 可透過 facebook.com/{id} 找到該貼文
-            'created_time' 2018-12-18T07:22:06+0000 // 貼文時間點
+            "shares" : {int}, // 多少人分享
+            "url" : "https://www.facebook.com/{id}", //該貼文
+            "likes" : {int}, // 多少人按讚
+            'created_time' : '2018-12-18T07:22:06+0000' // 貼文時間點
         },
         {
             'full_picture' : {imageUrl},


### PR DESCRIPTION
- [x] url
- [x] likes 
- [x] shares

目前取得likes(按讚數)的方法不太好，每篇貼文我必須要個別 request 才能查到每篇貼文的按讚數。如果有找到更好的 api 方式我會改掉，但目前我只找到這個方法。