### PR TITLE
add: session api 增加 tag 篩選於主要議程清單

### DIFF
--- a/api/app/Http/Controllers/SessionController.php
+++ b/api/app/Http/Controllers/SessionController.php
@@ -17,6 +17,8 @@ class SessionController extends Controller
         'company_e',
         'job_title',
         'job_title_e',
+        'summary',
+        'summary_e',
         'photo_for_session_web',
         'photo_for_session_mobile',
         'topic',
@@ -95,9 +97,20 @@ class SessionController extends Controller
      *
      * @return \Illuminate\Http\Response
      */
-    public function getSessionList()
+    public function getSessionList(Request $request)
     {
-        return $this->returnSuccess('success', array_values($this->sessions));
+        $tags = $request->input('tags', '');
+        if ($tags === '') {
+            return $this->returnSuccess('success', array_values($this->sessions));
+        }
+        $tags = explode(',', $tags);
+        $output = array_filter($this->sessions, function ($session) use ($tags) {
+            $filters = array_merge($session['tags_tech'], $session['tags_design'], $session['tags_other']);
+            $intersect = array_intersect($tags, $filters);
+            return $tags === $intersect;
+        });
+
+        return $this->returnSuccess('success', array_values($output));
     }
 
     /**

--- a/api/docs/session.md
+++ b/api/docs/session.md
@@ -1,6 +1,9 @@
 # 主要議程 API
 
 ## 主要議程表
+
+議程時間表
+
 - **URL**
 
     /api/2019/session
@@ -192,13 +195,23 @@
   }
   ```
 ## 主要議程清單
+
+提供過濾議程標籤後的議程清單
+
 - **URL**
 
-    /api/2019/session/list
+    /api/2019/session/list?tags=:tags
 
 - **Method**
 
     `GET`
+
+- **URL Params**
+
+    **Optional:**
+
+    - tags=[string] 
+      - e.g., `/api/2019/session/list?tags=ai,cloud`
 
 - **Success Response**
 
@@ -275,9 +288,12 @@
   ```
   
 ## 主要議程資訊
+
+提供單一議程資訊
+
 - **URL**
 
-    /api/2019/conf/session/:session_id
+    /api/2019/session/:session_id
 
 - **Method**
 

--- a/api/tests/app/Http/Controllers/SessionControllerTest.php
+++ b/api/tests/app/Http/Controllers/SessionControllerTest.php
@@ -17,6 +17,8 @@ class SessionController extends TestCase
         'company_e',
         'job_title',
         'job_title_e',
+        'summary',
+        'summary_e',
         'photo_for_session_web',
         'photo_for_session_mobile',
         'topic',
@@ -93,6 +95,37 @@ class SessionController extends TestCase
             'success' => true,
             'message' => 'success',
             'data' => $compared,
+        ]);
+    }
+
+    public function testGetSessionListWithTags()
+    {
+        $id = rand(1, count($this->sessions));
+        $tags = implode(',', ['ai', 'cloud']);
+        $response = $this->get('/api/2019/session/list?tags=' . $tags);
+        $compared = array_values($this->sessions);
+
+        $this->assertEquals(200, $this->response->status());
+
+        $response->seeJsonEquals([
+            'success' => true,
+            'message' => 'success',
+            'data' => $compared,
+        ]);
+    }
+
+    public function testGetSessionListWithNoExistTags()
+    {
+        $id = rand(1, count($this->sessions));
+        $tags = implode(['qwdfwe','acvbb']);
+        $response = $this->get('/api/2019/session/list?tags=' . $tags);
+
+        $this->assertEquals(200, $this->response->status());
+
+        $response->seeJsonEquals([
+            'success' => true,
+            'message' => 'success',
+            'data' => [],
         ]);
     }
 


### PR DESCRIPTION
#170 
增加 tag 篩選於主要議程清單 api
`/api/2019/session/list`
`/api/2019/session/list?tags=:tags`

@hashman 好了，麻煩幫我檢查