### PR TITLE
Add redis for facebook api

### DIFF
--- a/api/app/Http/Controllers/FacebookController.php
+++ b/api/app/Http/Controllers/FacebookController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Exception;
 
 class FacebookController extends Controller
 {
@@ -18,37 +20,23 @@ class FacebookController extends Controller
     public function getPosts(Request $request)
     {
         $limit = $request->get('limit', 20);
+        $facebookPostsKey = 'facebookPosts' . $limit;
         // handle error;
         if ($limit > 100) {
             return $this->returnError('can not access over than 100 posts');
         }
-        $token = env('FACEBOOK_TOKEN');
-        $fields = ['full_picture', 'message', 'id', 'shares', 'created_time', 'likes.summary(true)'];
-        $baseUrl = $this->mopconApiUrl;
-        $baseUrl .= 'feed?fields=';
-        $baseUrl .= implode(',', $fields);
-        $baseUrl .= '&limit='.$limit;
-        $baseUrl .= '&access_token='.$token;
-        $feedsRes = $this->requestFacebookApi($baseUrl);
-        $feedsData = json_decode($feedsRes->getContent(), true);
-        // handle error;
-        if (!$feedsData['success']) {
-            return $feedsRes;
+        if (Cache::has($facebookPostsKey)) {
+            return $this->returnSuccess('Success get posts', Cache::get($facebookPostsKey));
         }
-        // handle error;
-        if (!isset($feedsData['data']['data'])) {
-            return $this->returnNotFoundError();
+        try {
+            $facebookPosts = json_decode($this->dataProcesser($request, $limit)->getContent(), true)['data'];
+            Cache::put($facebookPostsKey, $facebookPosts, 600);
+            return $this->returnSuccess('Success get posts', $facebookPosts);
+        } catch (Exception $e) {
+            return $this->returnError($e->getMessage());
         }
-        $postsData = $feedsData['data']['data'];
-        foreach ($postsData as $key => $value) {
-            $postsData[$key]['shares'] = $postsData[$key]['shares']['count'] ?? 0;
-            $postsData[$key]['likes'] = $postsData[$key]['likes']['summary']['total_count'];
-            $postsData[$key]['url'] = $this->facebookUrl.$postsData[$key]['id'];
-            $postsData[$key]['created_time'] = strtotime($postsData[$key]['created_time']);
-        }
-        return $this->returnSuccess('Success get posts', $postsData);
     }
-    private function requestFacebookApi($url)
+    private function requestFacebookApi(String $url)
     {
         // request facebook api
         $ch = curl_init();
@@ -61,9 +49,36 @@ class FacebookController extends Controller
 
         // handle error; error output
         if (curl_getinfo($ch, CURLINFO_HTTP_CODE) !== 200) {
-            return $this->returnError('Token invalid');
+            throw new Exception("Token invalid");
         }
         curl_close($ch);
         return $this->returnSuccess('', $dataJson);
+    }
+    private function dataProcesser(Request $request, Int $limit)
+    {
+        $token = env('FACEBOOK_TOKEN');
+        $fields = ['full_picture', 'message', 'id', 'shares', 'created_time', 'likes.summary(true)'];
+        $baseUrl = $this->mopconApiUrl;
+        $baseUrl .= 'feed?fields=';
+        $baseUrl .= implode(',', $fields);
+        $baseUrl .= '&limit='.$limit;
+        $baseUrl .= '&access_token='.$token;
+        try {
+            $feedsData = json_decode($this->requestFacebookApi($baseUrl)->getContent(), true);
+            // handle error;
+            if (!isset($feedsData['data']['data'])) {
+                throw new Exception("Not found");
+            }
+            $postsData = $feedsData['data']['data'];
+            foreach ($postsData as $key => $value) {
+                $postsData[$key]['shares'] = $postsData[$key]['shares']['count'] ?? 0;
+                $postsData[$key]['likes'] = $postsData[$key]['likes']['summary']['total_count'];
+                $postsData[$key]['url'] = $this->facebookUrl.$postsData[$key]['id'];
+                $postsData[$key]['created_time'] = strtotime($postsData[$key]['created_time']);
+            }
+            return $this->returnSuccess('Success get posts', $postsData);
+        } catch (Exception $e) {
+            throw new Exception($e->getMessage());
+        }
     }
 }

--- a/api/bootstrap/app.php
+++ b/api/bootstrap/app.php
@@ -23,9 +23,8 @@ $app = new Laravel\Lumen\Application(
     dirname(__DIR__)
 );
 
-// $app->withFacades();
-
-// $app->withEloquent();
+$app->withFacades();
+$app->withEloquent();
 
 /*
 |--------------------------------------------------------------------------
@@ -80,7 +79,7 @@ $app->configure('logging');
 | totally optional, so you are not required to uncomment this line.
 |
 */
-
+$app->register(Illuminate\Redis\RedisServiceProvider::class);
 // $app->register(App\Providers\AppServiceProvider::class);
 // $app->register(App\Providers\AuthServiceProvider::class);
 // $app->register(App\Providers\EventServiceProvider::class);

--- a/api/composer.json
+++ b/api/composer.json
@@ -6,6 +6,7 @@
     "type": "project",
     "require": {
         "php": ">=7.1.3",
+        "illuminate/redis": "5.8.*",
         "laravel/lumen-framework": "5.8.*",
         "rollbar/rollbar": "~1.5"
     },

--- a/api/composer.lock
+++ b/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9c9b4edb7a9462a14496d8b8d909ebd1",
+    "content-hash": "285fd486a09015503c246d7db190fbcc",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -582,16 +582,16 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v5.8.27",
+            "version": "v5.8.35",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
-                "reference": "f6a2633c280b3f0efcd5a6d2d4a975dfa26033e8"
+                "reference": "00fc6afee788fa07c311b0650ad276585f8aef96"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/contracts/zipball/f6a2633c280b3f0efcd5a6d2d4a975dfa26033e8",
-                "reference": "f6a2633c280b3f0efcd5a6d2d4a975dfa26033e8",
+                "url": "https://api.github.com/repos/illuminate/contracts/zipball/00fc6afee788fa07c311b0650ad276585f8aef96",
+                "reference": "00fc6afee788fa07c311b0650ad276585f8aef96",
                 "shasum": ""
             },
             "require": {
@@ -622,7 +622,7 @@
             ],
             "description": "The Illuminate Contracts package.",
             "homepage": "https://laravel.com",
-            "time": "2019-06-24T11:16:37+00:00"
+            "time": "2019-07-30T13:57:21+00:00"
         },
         {
             "name": "illuminate/database",
@@ -1111,6 +1111,51 @@
             "description": "The Illuminate Queue package.",
             "homepage": "https://laravel.com",
             "time": "2019-06-04T14:33:55+00:00"
+        },
+        {
+            "name": "illuminate/redis",
+            "version": "v5.8.35",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/redis.git",
+                "reference": "59f47da5c12a5d808582b2c1c74b2912a4e2176e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/redis/zipball/59f47da5c12a5d808582b2c1c74b2912a4e2176e",
+                "reference": "59f47da5c12a5d808582b2c1c74b2912a4e2176e",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "5.8.*",
+                "illuminate/support": "5.8.*",
+                "php": "^7.1.3",
+                "predis/predis": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Redis\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Redis package.",
+            "homepage": "https://laravel.com",
+            "time": "2019-08-31T16:59:52+00:00"
         },
         {
             "name": "illuminate/session",
@@ -1751,6 +1796,56 @@
             "time": "2015-07-25T16:39:46+00:00"
         },
         {
+            "name": "predis/predis",
+            "version": "v1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nrk/predis.git",
+                "reference": "f0210e38881631afeafb56ab43405a92cafd9fd1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nrk/predis/zipball/f0210e38881631afeafb56ab43405a92cafd9fd1",
+                "reference": "f0210e38881631afeafb56ab43405a92cafd9fd1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8"
+            },
+            "suggest": {
+                "ext-curl": "Allows access to Webdis when paired with phpiredis",
+                "ext-phpiredis": "Allows faster serialization and deserialization of the Redis protocol"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Predis\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniele Alessandri",
+                    "email": "suppakilla@gmail.com",
+                    "homepage": "http://clorophilla.net"
+                }
+            ],
+            "description": "Flexible and feature-complete Redis client for PHP and HHVM",
+            "homepage": "http://github.com/nrk/predis",
+            "keywords": [
+                "nosql",
+                "predis",
+                "redis"
+            ],
+            "time": "2016-06-16T16:22:20+00:00"
+        },
+        {
             "name": "psr/container",
             "version": "1.0.0",
             "source": {
@@ -1938,8 +2033,8 @@
             "authors": [
                 {
                     "name": "Rollbar, Inc.",
-                    "role": "Developer",
-                    "email": "support@rollbar.com"
+                    "email": "support@rollbar.com",
+                    "role": "Developer"
                 }
             ],
             "description": "Monitors errors and exceptions and reports them to Rollbar",


### PR DESCRIPTION
#256 

1.`composer require illuminate/redis 5.8.*`
2. `composer update illuminate/contracts` (如果不做套件更新的話，redis的套件似乎會有bug無法使用)
3. 設定上要將 api 資料夾中 `.env` 修改
  CACHE_DRIVER=redis

我在這台的電腦的 redis 配置
host: 127.0.01
port: 6739

我使用 lumen 提供的 redis 套件來完成，使用的都是預設的設定，不確定是否在 dev 的環境上 redis 的設定是否有所不同。
