### PR TITLE
Remove Aspect mock initial from bootstrap/app.php

### DIFF
--- a/api/bootstrap/app.php
+++ b/api/bootstrap/app.php
@@ -4,13 +4,6 @@ use App\Providers\RollbarServiceProvider;
 
 require_once __DIR__.'/../vendor/autoload.php';
 
-$kernel = \AspectMock\Kernel::getInstance();
-$kernel->init([
-    'debug' => true,
-    'cacheDir' => '/tmp/l4-sample',
-    'includePaths' => [__DIR__.'/../app']
-]);
-
 (new Laravel\Lumen\Bootstrap\LoadEnvironmentVariables(
     dirname(__DIR__)
 ))->bootstrap();

--- a/api/phpunit.xml
+++ b/api/phpunit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false"
          backupStaticAttributes="false"
-         bootstrap="bootstrap/app.php"
+         bootstrap="tests/bootstrap.php"
          colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"

--- a/api/tests/bootstrap.php
+++ b/api/tests/bootstrap.php
@@ -1,0 +1,10 @@
+<?php
+
+require __DIR__ . '/../bootstrap/app.php';
+
+$kernel = \AspectMock\Kernel::getInstance();
+$kernel->init([
+    'debug' => true,
+    'cacheDir' => '/tmp/l4-sample',
+    'includePaths' => [__DIR__.'/../app']
+]);


### PR DESCRIPTION
由於 AspectMock 是測試才需要的東西，需要將他脫離正式環境之外

Production 環境建置的時候會使用 `composer install --no-dev` 的方式來 build ，所以不會有 AspectMock 相關的套件出現，這邊會出現問題，故將 phpunit 所使用的 bootstrap 與 production 的分開