### PR TITLE
網址帶有 utm 時，傳入購票 url

### DIFF
--- a/2019-dev/components/BtnBuy/index.vue
+++ b/2019-dev/components/BtnBuy/index.vue
@@ -18,7 +18,7 @@ export default {
             return this.$route.name === 'ticket' ? true : false;
         },
         buyTicketUrl() {
-            return this.$store.getters.buyTicketUrl;
+            return this.$store.getters.buyTicketUrl + this.$store.getters.utm;
         },
     },
 };

--- a/2019-dev/components/CardTicket/index.vue
+++ b/2019-dev/components/CardTicket/index.vue
@@ -1,5 +1,5 @@
 <template>
-    <a class="cardTicket" :class="[type, statusClass, {beEngaged: beEngaged}]" :href="link" target="_blank">
+    <a class="cardTicket" :class="[type, statusClass, {beEngaged: beEngaged}]" :href="link + utm" target="_blank">
         <div class="cardTicket__head">
             <div class="cardTicket__head__title">{{title}}</div>
             <div class="cardTicket__head__count" v-if="count">限量：{{count}}名</div>
@@ -84,6 +84,11 @@ export default {
             default: '',
         },
     },
+    data() {
+        return {
+            utm: '',
+        }
+    },
     computed: {
         btnText() {
             // status 狀態對應文字
@@ -113,6 +118,9 @@ export default {
             this.$emit('onTicketClick', ticket, price);
         },
     },
+    mounted() {
+        this.utm = this.$store.getters.utm;
+    }
 };
 </script>
 

--- a/2019-dev/components/Header/index.vue
+++ b/2019-dev/components/Header/index.vue
@@ -129,6 +129,24 @@ export default {
             }
         },
     },
+    mounted() {
+        const getUtm = document.cookie.match(new RegExp("(^| )mopcon_utm=([^;]*)(;|$)"));
+        if (getUtm != null) {
+            this.$store.dispatch('setUtmData', getUtm[2]);
+        }
+        if (location.search !== '') {
+            const loctionSearch = location.search.replace('?','').replace('/','')
+            const paramaters = loctionSearch.split('&');
+            const re = new RegExp('utm_');
+            this.utm = '?';
+            paramaters.forEach(ele => {
+                if(re.test(ele)) {
+                    this.utm += ele + '&';
+                }
+            });
+            this.$store.dispatch('setUtmData', this.utm);
+        }
+    },
 };
 </script>
 

--- a/2019-dev/pages/ticket/index.vue
+++ b/2019-dev/pages/ticket/index.vue
@@ -76,7 +76,7 @@ export default {
                         '兩日議程',
                         '下午茶點心',
                     ],
-                    link: 'https://lihi1.com/r0L6T',
+                    link: 'https://kktix.com/events/2019registernormal/registrations/new',
                 },
                 {
                     title: '會眾票',
@@ -87,7 +87,7 @@ export default {
                     beEngaged: false,
                     type: 'secondary',
                     lists: ['兩日議程', '下午茶點心'],
-                    link: 'https://lihi1.com/r0L6T',
+                    link: 'https://kktix.com/events/2019registernormal/registrations/new',
                 },
                 {
                     title: '相揪團購票',
@@ -100,12 +100,12 @@ export default {
                     lists: ['兩日議程', '下午茶點心'],
                     desc:
                         '適用 5 人企業團購<br>超過 15 人（ 16 人以上）請來信詳談',
-                    link: 'https://lihi1.com/r0L6T',
+                    link: ' https://kktix.com/events/2019registernormal/registrations/new',
                 },
                 {
                     title: 'Beengaged 醞釀之夜',
                     id: 3,
-                    status: 1,
+                    status: 2,
                     count: 30,
                     price: 800,
                     beEngaged: false,
@@ -129,7 +129,7 @@ export default {
                         '快速通關',
                         'Beengaged 醞釀之夜',
                     ],
-                    link: 'https://lihi1.com/d9LlC',
+                    link: 'https://kktix.com/events/2019registervip/registrations/new',
                 },
                 {
                     title: '尊爵不凡票',
@@ -147,7 +147,7 @@ export default {
                         'Beengaged 醞釀之夜',
                         'MOPCON 2019 獨家紀念品',
                     ],
-                    link: 'https://lihi1.com/d9LlC',
+                    link: 'https://kktix.com/events/2019registervip/registrations/new',
                 },
 
                 {

--- a/2019-dev/store/index.js
+++ b/2019-dev/store/index.js
@@ -65,6 +65,7 @@ export const state = () => ({
   sessionUnconfData: [],
   tags: [],
   buyTicketUrl: '',
+  utm: '',
 });
 
 export const mutations = {
@@ -103,6 +104,9 @@ export const mutations = {
   },
   setBuyTicketUrl(state, payload) {
     state.buyTicketUrl = payload;
+  },
+  setUtm(state, payload) {
+    state.utm = payload;
   },
 };
 
@@ -162,6 +166,13 @@ export const actions = {
       currency: 'TWD',
     });
   },
+  setUtmData({ commit }, utm) {
+    commit('setUtm', utm);
+    const nowDate = new Date();
+    nowDate.setTime(nowDate.getTime() + (60*60*1000));
+    const expires = "expires="+ nowDate.toUTCString();
+    document.cookie = `mopcon_utm=${utm};${expires}; path=/;`
+  },
 };
 
 export const getters = {
@@ -178,4 +189,5 @@ export const getters = {
   locales: state => state.locales,
   locale: state => state.locale,
   tags: state => state.tags,
+  utm: state => state.utm,
 };


### PR DESCRIPTION
#323 
有更新了～ 
當進入網頁有帶 utm 的話就存到 cookie，讓換頁時購票 url 也會戴上 utm
設定過期時間是一個小時

另外，『我要購票』按鈕的 url 目前看起來是寫這樣
`buyTicketUrl: process.env.BUY_TICKET_URL || 'https://kktix.com/events/2019registernormal/registrations/new',`
所以按鈕連結要非短網址的話，再請調整 env 的 BUY_TICKET_URL 應該就可以了

以上再請 @hashman 幫忙看一下，謝謝 :D