### PR TITLE
調整官網 API 架構

### DIFF
--- a/api/app/Http/Controllers/FacebookController.php
+++ b/api/app/Http/Controllers/FacebookController.php
@@ -57,7 +57,7 @@ class FacebookController extends Controller
     private function dataProcesser(Request $request, Int $limit)
     {
         $token = env('FACEBOOK_TOKEN');
-        $fields = ['full_picture', 'message', 'id', 'shares', 'created_time', 'likes.summary(true)'];
+        $fields = ['full_picture', 'message', 'id', 'shares', 'created_time', 'likes.summary(true)', 'permalink_url'];
         $baseUrl = $this->mopconApiUrl;
         $baseUrl .= 'feed?fields=';
         $baseUrl .= implode(',', $fields);
@@ -73,8 +73,9 @@ class FacebookController extends Controller
             foreach ($postsData as $key => $value) {
                 $postsData[$key]['shares'] = $postsData[$key]['shares']['count'] ?? 0;
                 $postsData[$key]['likes'] = $postsData[$key]['likes']['summary']['total_count'];
-                $postsData[$key]['url'] = $this->facebookUrl.$postsData[$key]['id'];
+                $postsData[$key]['url'] = $postsData[$key]['permalink_url'];
                 $postsData[$key]['created_time'] = strtotime($postsData[$key]['created_time']);
+                unset($postsData[$key]['permalink_url']);
             }
             return $this->returnSuccess('Success get posts', $postsData);
         } catch (Exception $e) {

--- a/api/app/Http/Controllers/Year2019/AppHomeController.php
+++ b/api/app/Http/Controllers/Year2019/AppHomeController.php
@@ -1,7 +1,9 @@
 <?php
 
-namespace App\Http\Controllers;
+namespace App\Http\Controllers\Year2019;
 
+use App\Http\Controllers\Controller;
+use App\Http\Controllers\ApiTrait;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 

--- a/api/app/Http/Controllers/Year2019/BoardController.php
+++ b/api/app/Http/Controllers/Year2019/BoardController.php
@@ -1,7 +1,9 @@
 <?php
 
-namespace App\Http\Controllers;
+namespace App\Http\Controllers\Year2019;
 
+use App\Http\Controllers\Controller;
+use App\Http\Controllers\ApiTrait;
 use App\Service\SpeakerService;
 use App\Service\SessionService;
 use Illuminate\Http\Response;

--- a/api/app/Http/Controllers/Year2019/CommunityController.php
+++ b/api/app/Http/Controllers/Year2019/CommunityController.php
@@ -1,7 +1,9 @@
 <?php
 
-namespace App\Http\Controllers;
+namespace App\Http\Controllers\Year2019;
 
+use App\Http\Controllers\Controller;
+use App\Http\Controllers\ApiTrait;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 

--- a/api/app/Http/Controllers/Year2019/InitialController.php
+++ b/api/app/Http/Controllers/Year2019/InitialController.php
@@ -1,6 +1,9 @@
 <?php
 
-namespace App\Http\Controllers;
+namespace App\Http\Controllers\Year2019;
+
+use App\Http\Controllers\Controller;
+use App\Http\Controllers\ApiTrait;
 
 class InitialController extends Controller
 {

--- a/api/app/Http/Controllers/Year2019/NewsController.php
+++ b/api/app/Http/Controllers/Year2019/NewsController.php
@@ -1,6 +1,9 @@
 <?php
 
-namespace App\Http\Controllers;
+namespace App\Http\Controllers\Year2019;
+
+use App\Http\Controllers\Controller;
+use App\Http\Controllers\ApiTrait;
 
 class NewsController extends Controller
 {

--- a/api/app/Http/Controllers/Year2019/SessionController.php
+++ b/api/app/Http/Controllers/Year2019/SessionController.php
@@ -1,7 +1,9 @@
 <?php
 
-namespace App\Http\Controllers;
+namespace App\Http\Controllers\Year2019;
 
+use App\Http\Controllers\Controller;
+use App\Http\Controllers\ApiTrait;
 use App\Service\SpeakerService;
 use App\Service\SessionService;
 use Illuminate\Http\Request;

--- a/api/app/Http/Controllers/Year2019/SpeakerController.php
+++ b/api/app/Http/Controllers/Year2019/SpeakerController.php
@@ -1,9 +1,11 @@
 <?php
 
-namespace App\Http\Controllers;
+namespace App\Http\Controllers\Year2019;
 
 use App\Service\SpeakerService;
 use Illuminate\Http\Response;
+use App\Http\Controllers\Controller;
+use App\Http\Controllers\ApiTrait;
 
 class SpeakerController extends Controller
 {

--- a/api/app/Http/Controllers/Year2019/SponsorController.php
+++ b/api/app/Http/Controllers/Year2019/SponsorController.php
@@ -1,10 +1,12 @@
 <?php
 
-namespace App\Http\Controllers;
+namespace App\Http\Controllers\Year2019;
 
 use App\Service\SpeakerService;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use App\Http\Controllers\Controller;
+use App\Http\Controllers\ApiTrait;
 
 class SponsorController extends Controller
 {

--- a/api/app/Http/Controllers/Year2019/UnconfController.php
+++ b/api/app/Http/Controllers/Year2019/UnconfController.php
@@ -1,9 +1,11 @@
 <?php
 
-namespace App\Http\Controllers;
+namespace App\Http\Controllers\Year2019;
 
 use Illuminate\Http\Request;
 use App\Service\SessionService;
+use App\Http\Controllers\Controller;
+use App\Http\Controllers\ApiTrait;
 
 class UnconfController extends Controller
 {

--- a/api/app/Http/Controllers/Year2019/VolunteerController.php
+++ b/api/app/Http/Controllers/Year2019/VolunteerController.php
@@ -1,9 +1,11 @@
 <?php
 
-namespace App\Http\Controllers;
+namespace App\Http\Controllers\Year2019;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use App\Http\Controllers\Controller;
+use App\Http\Controllers\ApiTrait;
 
 class VolunteerController extends Controller
 {

--- a/api/routes/web.php
+++ b/api/routes/web.php
@@ -13,53 +13,60 @@
 
 $router->group(['prefix' => 'api'], function ($router) {
     $router->group(['prefix' => '2019'], function ($router) {
-        $router->get('initial', 'Year2019\InitialController@index');
-        $router->group(['prefix' => 'community'], function ($router) {
-            $router->get('/', 'Year2019\CommunityController@index');
-            $router->get('/organizer/{id}', 'Year2019\CommunityController@getOrganizer');
-            $router->get('/participant/{id}', 'Year2019\CommunityController@getParticipant');
-            $router->get('/images/{name}', 'Year2019\CommunityController@imagesView');
-        });
-        $router->group(['prefix' => 'volunteer'], function ($router) {
-            $router->get('/', 'Year2019\VolunteerController@index');
-            $router->get('/{id}', 'Year2019\VolunteerController@show');
-            $router->get('/images/{name}', 'Year2019\VolunteerController@imagesView');
-        });
         $router->group(['prefix' => 'facebook'], function ($router) {
             $router->get('posts', 'FacebookController@getPosts');
         });
-        $router->group(['prefix' => 'sponsor'], function ($router) {
-            $router->get('', 'Year2019\SponsorController@index');
-            $router->get('images/{name}', 'Year2019\SponsorController@imagesView');
+        $router->group(['namespace' => 'Year2019'], function () use ($router) {
+            $router->get('initial', 'InitialController@index');
+            $router->group(['prefix' => 'community'], function ($router) {
+                $router->get('/', 'CommunityController@index');
+                $router->get('/organizer/{id}', 'CommunityController@getOrganizer');
+                $router->get('/participant/{id}', 'CommunityController@getParticipant');
+                $router->get('/images/{name}', 'CommunityController@imagesView');
+            });
+            $router->group(['prefix' => 'volunteer'], function ($router) {
+                $router->get('/', 'VolunteerController@index');
+                $router->get('/{id}', 'VolunteerController@show');
+                $router->get('/images/{name}', 'VolunteerController@imagesView');
+            });
+            $router->group(['prefix' => 'sponsor'], function ($router) {
+                $router->get('', 'SponsorController@index');
+                $router->get('images/{name}', 'SponsorController@imagesView');
+            });
+            // Speaker
+            $router->group(['prefix' => 'speaker'], function ($router) {
+                $router->get('', 'SpeakerController@index');
+                $router->get('tags', 'SpeakerController@getTags');
+                $router->get('{id}', 'SpeakerController@show');
+                $router->get('images/{platform}/{name}', 'SpeakerController@imagesView');
+            });
+            $router->group(['prefix' => 'unconf'], function ($router) {
+                $router->get('/', 'UnconfController@index');
+                $router->get('/list', 'UnconfController@getUnconfList');
+                $router->get('/{id}', 'UnconfController@show');
+            });
+            $router->group(['prefix' => 'news'], function ($router) {
+                $router->get('', 'NewsController@index');
+                $router->get('{id}', 'NewsController@show');
+            });
+            $router->group(['prefix' => 'session'], function ($router) {
+                $router->get('/', 'SessionController@index');
+                $router->get('/list', 'SessionController@getSessionList');
+                $router->get('/{id}', 'SessionController@show');
+            });
+            $router->group(['prefix' => 'home'], function ($router) {
+                $router->get('/', 'AppHomeController@index');
+                $router->get('/images/{name}', 'AppHomeController@show');
+            });
+            $router->group(['prefix' => 'board'], function ($router) {
+                $router->get('/{room}', 'BoardController@index');
+                $router->get('images/{type}/{name}', 'BoardController@imagesView');
+            });
         });
-        // Speaker
-        $router->group(['prefix' => 'speaker'], function ($router) {
-            $router->get('', 'Year2019\SpeakerController@index');
-            $router->get('tags', 'Year2019\SpeakerController@getTags');
-            $router->get('{id}', 'Year2019\SpeakerController@show');
-            $router->get('images/{platform}/{name}', 'Year2019\SpeakerController@imagesView');
-        });
-        $router->group(['prefix' => 'unconf'], function ($router) {
-            $router->get('/', 'Year2019\UnconfController@index');
-            $router->get('/list', 'Year2019\UnconfController@getUnconfList');
-            $router->get('/{id}', 'Year2019\UnconfController@show');
-        });
-        $router->group(['prefix' => 'news'], function ($router) {
-            $router->get('', 'Year2019\NewsController@index');
-            $router->get('{id}', 'Year2019\NewsController@show');
-        });
-        $router->group(['prefix' => 'session'], function ($router) {
-            $router->get('/', 'Year2019\SessionController@index');
-            $router->get('/list', 'Year2019\SessionController@getSessionList');
-            $router->get('/{id}', 'Year2019\SessionController@show');
-        });
-        $router->group(['prefix' => 'home'], function ($router) {
-            $router->get('/', 'Year2019\AppHomeController@index');
-            $router->get('/images/{name}', 'Year2019\AppHomeController@show');
-        });
-        $router->group(['prefix' => 'board'], function ($router) {
-            $router->get('/{room}', 'Year2019\BoardController@index');
-            $router->get('images/{type}/{name}', 'Year2019\BoardController@imagesView');
+    });
+    $router->group(['prefix' => '2020'], function ($router) {
+        $router->group(['prefix' => 'facebook'], function ($router) {
+            $router->get('posts', 'FacebookController@getPosts');
         });
     });
 });

--- a/api/routes/web.php
+++ b/api/routes/web.php
@@ -13,53 +13,53 @@
 
 $router->group(['prefix' => 'api'], function ($router) {
     $router->group(['prefix' => '2019'], function ($router) {
-        $router->get('initial', 'InitialController@index');
+        $router->get('initial', 'Year2019\InitialController@index');
         $router->group(['prefix' => 'community'], function ($router) {
-            $router->get('/', 'CommunityController@index');
-            $router->get('/organizer/{id}', 'CommunityController@getOrganizer');
-            $router->get('/participant/{id}', 'CommunityController@getParticipant');
-            $router->get('/images/{name}', 'CommunityController@imagesView');
+            $router->get('/', 'Year2019\CommunityController@index');
+            $router->get('/organizer/{id}', 'Year2019\CommunityController@getOrganizer');
+            $router->get('/participant/{id}', 'Year2019\CommunityController@getParticipant');
+            $router->get('/images/{name}', 'Year2019\CommunityController@imagesView');
         });
         $router->group(['prefix' => 'volunteer'], function ($router) {
-            $router->get('/', 'VolunteerController@index');
-            $router->get('/{id}', 'VolunteerController@show');
-            $router->get('/images/{name}', 'VolunteerController@imagesView');
+            $router->get('/', 'Year2019\VolunteerController@index');
+            $router->get('/{id}', 'Year2019\VolunteerController@show');
+            $router->get('/images/{name}', 'Year2019\VolunteerController@imagesView');
         });
         $router->group(['prefix' => 'facebook'], function ($router) {
             $router->get('posts', 'FacebookController@getPosts');
         });
         $router->group(['prefix' => 'sponsor'], function ($router) {
-            $router->get('', 'SponsorController@index');
-            $router->get('images/{name}', 'SponsorController@imagesView');
+            $router->get('', 'Year2019\SponsorController@index');
+            $router->get('images/{name}', 'Year2019\SponsorController@imagesView');
         });
         // Speaker
         $router->group(['prefix' => 'speaker'], function ($router) {
-            $router->get('', 'SpeakerController@index');
-            $router->get('tags', 'SpeakerController@getTags');
-            $router->get('{id}', 'SpeakerController@show');
-            $router->get('images/{platform}/{name}', 'SpeakerController@imagesView');
+            $router->get('', 'Year2019\SpeakerController@index');
+            $router->get('tags', 'Year2019\SpeakerController@getTags');
+            $router->get('{id}', 'Year2019\SpeakerController@show');
+            $router->get('images/{platform}/{name}', 'Year2019\SpeakerController@imagesView');
         });
         $router->group(['prefix' => 'unconf'], function ($router) {
-            $router->get('/', 'UnconfController@index');
-            $router->get('/list', 'UnconfController@getUnconfList');
-            $router->get('/{id}', 'UnconfController@show');
+            $router->get('/', 'Year2019\UnconfController@index');
+            $router->get('/list', 'Year2019\UnconfController@getUnconfList');
+            $router->get('/{id}', 'Year2019\UnconfController@show');
         });
         $router->group(['prefix' => 'news'], function ($router) {
-            $router->get('', 'NewsController@index');
-            $router->get('{id}', 'NewsController@show');
+            $router->get('', 'Year2019\NewsController@index');
+            $router->get('{id}', 'Year2019\NewsController@show');
         });
         $router->group(['prefix' => 'session'], function ($router) {
-            $router->get('/', 'SessionController@index');
-            $router->get('/list', 'SessionController@getSessionList');
-            $router->get('/{id}', 'SessionController@show');
+            $router->get('/', 'Year2019\SessionController@index');
+            $router->get('/list', 'Year2019\SessionController@getSessionList');
+            $router->get('/{id}', 'Year2019\SessionController@show');
         });
         $router->group(['prefix' => 'home'], function ($router) {
-            $router->get('/', 'AppHomeController@index');
-            $router->get('/images/{name}', 'AppHomeController@show');
+            $router->get('/', 'Year2019\AppHomeController@index');
+            $router->get('/images/{name}', 'Year2019\AppHomeController@show');
         });
         $router->group(['prefix' => 'board'], function ($router) {
-            $router->get('/{room}', 'BoardController@index');
-            $router->get('images/{type}/{name}', 'BoardController@imagesView');
+            $router->get('/{room}', 'Year2019\BoardController@index');
+            $router->get('images/{type}/{name}', 'Year2019\BoardController@imagesView');
         });
     });
 });

--- a/api/tests/app/Http/Controllers/AppHomeControllerTest.php
+++ b/api/tests/app/Http/Controllers/AppHomeControllerTest.php
@@ -15,7 +15,7 @@ class AppHomeController extends TestCase
         putenv('APP_ENV=develop');
 
         $dummyGoogleSheet = '{"feed": {"entry": [{ "gsx$id": { "$t": "1" }, "gsx$date": { "$t": "2018/10/20 9:00" }, "gsx$title": { "$t": "Telegram 聊天頻道上線嚕" }, "gsx$description": { "$t": "歡迎大家一起加入聊天！！" }, "gsx$link": { "$t": "tg://resolve?domain=mopcon" } }]}}';
-        test::double('App\Http\Controllers\NewsController', ['getSheetData' => $dummyGoogleSheet]);
+        test::double('App\Http\Controllers\Year2019\NewsController', ['getSheetData' => $dummyGoogleSheet]);
 
         $path = __DIR__ . '/../../../../resource/assets/json/';
         if (env('APP_ENV') === 'production') {

--- a/api/tests/app/Http/Controllers/NewsControllerTest.php
+++ b/api/tests/app/Http/Controllers/NewsControllerTest.php
@@ -9,7 +9,7 @@ class NewsControllerTest extends TestCase
         parent::setUp();
         putenv('APP_ENV=develop');
         $dummyGoogleSheet = '{"feed": {"entry": [{ "gsx$id": { "$t": "1" }, "gsx$date": { "$t": "2018/10/20 9:00" }, "gsx$title": { "$t": "Telegram 聊天頻道上線嚕" }, "gsx$description": { "$t": "歡迎大家一起加入聊天！！" }, "gsx$link": { "$t": "tg://resolve?domain=mopcon" } }]}}';
-        test::double('App\Http\Controllers\NewsController', ['getSheetData' => $dummyGoogleSheet]); 
+        test::double('App\Http\Controllers\Year2019\NewsController', ['getSheetData' => $dummyGoogleSheet]);
     }
     
     public function testAllNews()


### PR DESCRIPTION
#381
請 @hashman 幫忙 review

架構調整 : 
1. 建立 Year2019 資料夾  `app\Http\Controllers\Year2019`
2. 調整 2019 Api 的 namespace 

facebook api : 
因為內容完全一樣，不做抽象，直接用 router 區分

之後 2020 的 Web API 大致上會跟 2019 的邏輯相似
所以之後須將 2019 Api 的邏輯 抽象出來
controller 預計放在  Year2020 資料夾 (  `app\Http\Controllers\Year2020` )
抽象出來的放置在 Service ( `app\Service` )

資料的存放方式先維持跟去年一樣以人工更新