### PR TITLE
新增講者標籤顏色多年份支援

### DIFF
--- a/api/app/Http/Controllers/BaseSessionController.php
+++ b/api/app/Http/Controllers/BaseSessionController.php
@@ -53,13 +53,16 @@ class BaseSessionController extends Controller
         if (env('APP_ENV') === 'production') {
             $speaker_resource_path = $this->path . 'speaker.json';
             $sponsor_resource_path = $this->path . 'sponsor.json';
+            $tag_group_resource_path = $this->path . 'tag-group.json';
         } else {
             $speaker_resource_path = $this->path . 'speaker-dev.json';
             $sponsor_resource_path = $this->path . 'sponsor-dev.json';
+            $tag_group_resource_path = $this->path . 'tag-group-dev.json';
         }
 
         $speakers = json_decode(file_get_contents($speaker_resource_path), true);
         $sponsors = json_decode(file_get_contents($sponsor_resource_path), true);
+        $tagGroupSetting = json_decode(file_get_contents($tag_group_resource_path), true);
         $this->sponsors = [];
         foreach ($sponsors as $sponsor) {
             $this->sponsors[(int) $sponsor['sponsor_id']] = [
@@ -68,7 +71,7 @@ class BaseSessionController extends Controller
                 'logo_path' => url($sponsor['logo_path']),
             ];
         }
-        $this->speakerService = new SpeakerService($this->jsonAry);
+        $this->speakerService = new SpeakerService($this->jsonAry, $tagGroupSetting);
         $this->sessionSpeakerMapping = $this->speakerService->getSessionSpeakerMapping();
         $this->sessions = $this->transSpeakerToSession($speakers);
     }

--- a/api/app/Http/Controllers/BaseSpeakerController.php
+++ b/api/app/Http/Controllers/BaseSpeakerController.php
@@ -13,14 +13,22 @@ class BaseSpeakerController extends Controller
 
     protected $function = 'speaker';
 
-    private $service;
+    protected $service;
 
     public function __construct()
     {
         parent::__construct();
-        $sessionFileName = env('APP_ENV') === 'production' ? '/session.json' : '/session-dev.json';
-        $sessionAry = json_decode(file_get_contents($this->path . $sessionFileName), true);
-        $this->service = new SpeakerService($sessionAry);
+        if (env('APP_ENV') === 'production') {
+            $session_resource_path = $this->path . 'session.json';
+            $tag_group_resource_path = $this->path . 'tag-group.json';
+        } else {
+            $session_resource_path = $this->path . 'session-dev.json';
+            $tag_group_resource_path = $this->path . 'tag-group-dev.json';
+        }
+
+        $sessionAry = json_decode(file_get_contents($session_resource_path), true);
+        $tagGroupSetting = json_decode(file_get_contents($tag_group_resource_path), true);
+        $this->service = new SpeakerService($sessionAry, $tagGroupSetting);
         foreach ($this->jsonAry as &$row) {
             $row = $this->service->parse($row);
         }

--- a/api/app/Http/Controllers/BaseSponsorController.php
+++ b/api/app/Http/Controllers/BaseSponsorController.php
@@ -38,11 +38,19 @@ class BaseSponsorController extends Controller
     {
         $sponsorIds = $request->get('sponsor_id', '');
         $sponsorIdArr = $sponsorIds == '' ? [] : explode(",", $sponsorIds);
-        $speakerFilePath = env('APP_ENV') === 'production' ? 'speaker.json' : 'speaker-dev.json';
-        $this->speakerAry = json_decode(file_get_contents($this->path . $speakerFilePath), true);
-        $sessionFileName = env('APP_ENV') === 'production' ? '/session.json' : '/session-dev.json';
-        $sessionAry = json_decode(file_get_contents($this->path . $sessionFileName), true);
-        $this->speakerService = new SpeakerService($sessionAry);
+        if (env('APP_ENV') === 'production') {
+            $speaker_resource_path = $this->path . 'speaker.json';
+            $session_resource_path = $this->path . 'session.json';
+            $tag_group_resource_path = $this->path . 'tag-group.json';
+        } else {
+            $speaker_resource_path = $this->path . 'speaker-dev.json';
+            $session_resource_path = $this->path . 'session-dev.json';
+            $tag_group_resource_path = $this->path . 'tag-group-dev.json';
+        }
+        $sessionAry = json_decode(file_get_contents($session_resource_path), true);
+        $tagGroupSetting = json_decode(file_get_contents($tag_group_resource_path), true);
+        $this->speakerAry = json_decode(file_get_contents($speaker_resource_path), true);
+        $this->speakerService = new SpeakerService($sessionAry, $tagGroupSetting);
         $this->sessionSpeakerMapping = $this->speakerService->getSessionSpeakerMapping();
 
         return count($sponsorIdArr) ? $this->getSpecificSponsors($this->jsonAry, $sponsorIdArr) : $this->getAllSponsors($this->jsonAry);

--- a/api/app/Http/Controllers/Year2019/BoardController.php
+++ b/api/app/Http/Controllers/Year2019/BoardController.php
@@ -92,13 +92,16 @@ class BoardController extends Controller
         if (env('APP_ENV') === 'production') {
             $speaker_resource_path = $this->path . 'speaker.json';
             $board_resource_path = $this->path . 'board.json';
+            $tag_group_resource_path = $this->path . 'tag-group.json';
         } else {
             $speaker_resource_path = $this->path . 'speaker-dev.json';
             $board_resource_path = $this->path . 'board-dev.json';
+            $tag_group_resource_path = $this->path . 'tag-group-dev.json';
         }
 
         $speakers = json_decode(file_get_contents($speaker_resource_path), true);
         $board_ads = json_decode(file_get_contents($board_resource_path), true);
+        $tagGroupSetting = json_decode(file_get_contents($tag_group_resource_path), true);
         $this->sponsor_ads = [];
         foreach ($board_ads as $ad) {
             $this->sponsor_ads[] = [
@@ -106,7 +109,7 @@ class BoardController extends Controller
             ];
         }
 
-        $this->speakerService = new SpeakerService($this->jsonAry);
+        $this->speakerService = new SpeakerService($this->jsonAry, $tagGroupSetting);
         $this->sessionSpeakerMapping = $this->speakerService->getSessionSpeakerMapping();
         $this->sessions = $this->transSpeakerToSession($speakers);
         $this->board = $this->arrangeSessions($this->jsonAry);

--- a/api/app/Http/Controllers/Year2019/SpeakerController.php
+++ b/api/app/Http/Controllers/Year2019/SpeakerController.php
@@ -7,4 +7,28 @@ use App\Http\Controllers\BaseSpeakerController;
 class SpeakerController extends BaseSpeakerController
 {
     protected $year = 2019;
+
+    /**
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function getTags()
+    {
+        try {
+            $tags = [];
+            foreach ($this->jsonAry as $speaker) {
+                $tags = array_merge($tags, array_column($speaker['tags'], 'name'));
+            }
+
+            $outputTags = $this->service->parseTags(array_values(array_unique($tags)));
+            foreach ($outputTags as &$tag) {
+                // 將 color 替換成 web 的色碼
+                // 因 2019 Mobile 及 App 顏色相同，在不修改回傳結構的情況下以此方式處理
+                $tag["color"] = $tag["color"]["web"];
+            }
+
+            return $this->returnSuccess('Success.', $outputTags);
+        } catch (\Exception $e) {
+            $this->returnError($e->getMessage());
+        }
+    }
 }

--- a/api/resource/assets/json/2019/tag-group-dev.json
+++ b/api/resource/assets/json/2019/tag-group-dev.json
@@ -1,0 +1,30 @@
+{
+    "defaultColor": {
+        "web": "#01aaf0",
+        "mobile": "#01aaf0"
+    }
+    ,
+    "group": [
+        {
+            "name": "design",
+            "color": {
+                "web": "#98ce02",
+                "mobile": "#98ce02"
+            },
+            "members": [
+                "UI/UX"
+            ]
+        },
+        {
+            "name": "other",
+            "color": {
+                "web": "#ff4492",
+                "mobile": "#ff4492"
+            },
+            "members": [
+                "Startup",
+                "Panel"
+            ]
+        }
+    ]
+}

--- a/api/resource/assets/json/2019/tag-group.json
+++ b/api/resource/assets/json/2019/tag-group.json
@@ -1,0 +1,30 @@
+{
+    "defaultColor": {
+        "web": "#01aaf0",
+        "mobile": "#01aaf0"
+    }
+    ,
+    "group": [
+        {
+            "name": "design",
+            "color": {
+                "web": "#98ce02",
+                "mobile": "#98ce02"
+            },
+            "members": [
+                "UI/UX"
+            ]
+        },
+        {
+            "name": "other",
+            "color": {
+                "web": "#ff4492",
+                "mobile": "#ff4492"
+            },
+            "members": [
+                "Startup",
+                "Panel"
+            ]
+        }
+    ]
+}

--- a/api/resource/assets/json/2020/tag-group-dev.json
+++ b/api/resource/assets/json/2020/tag-group-dev.json
@@ -1,0 +1,7 @@
+{
+    "defaultColor": {
+        "web": "#651fff",
+        "mobile": "#ffcc00"
+    },
+    "group": []
+}

--- a/api/resource/assets/json/2020/tag-group.json
+++ b/api/resource/assets/json/2020/tag-group.json
@@ -1,0 +1,7 @@
+{
+    "defaultColor": {
+        "web": "#651fff",
+        "mobile": "#ffcc00"
+    },
+    "group": []
+}


### PR DESCRIPTION
原先標籤的顏色寫死在 SpeakerService 中，僅能以 2019 的配色顯示，以目前 2020 的設計， Api 無法處理不同年份上顯示顏色不同的狀況，故作此調整

PS. 
今年比較特別的是 Web 及 Mobile 不同顏色，考量後續的擴充性，以 Web 及 Mobile 不同色的情境修改此程式
2019 的部分則是覆寫 BaseController 使其維持原本 Api 的資料結構

再麻煩 @FWcloud916  了