### PR TITLE
移除 2019 慶功宴相簿連結

### DIFF
--- a/locales/album/photodata.json
+++ b/locales/album/photodata.json
@@ -76,16 +76,6 @@
                         "src": "2019day2_01.jpg"
                     }
                 ]
-            },
-            {
-                "title": "慶功宴",
-                "link": "https://photos.app.goo.gl/rt9BivnnQzSa529n7",
-                "photos": [
-                    {
-                        "fileName": "",
-                        "src": "2017afterParty_01.jpg"
-                    }
-                ]
             }
         ]
     },


### PR DESCRIPTION
#598 
因為 JSON 檔無法用註解隱藏，所以就先將 2019 慶功宴移除～